### PR TITLE
Fix AttributeError when connection fails

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -123,7 +123,7 @@ class PioneerDevice(MediaPlayerEntity):
                     _LOGGER.info("Connected to %s:%d", self._host, self._port)
                 except:
                     _LOGGER.error("No connection to %s:%d, retry in 30s", \
-                        self._host, self.port)
+                        self._host, self._port)
                     await asyncio.sleep(30)
                     continue
 


### PR DESCRIPTION
## Summary
Fixed typo in error handling where `self.port` was used instead of `self._port`, causing `AttributeError` when the Pioneer receiver is unreachable.

## Details
- **Bug location**: Line 126 in `media_player.py`
- **Error**: `AttributeError: 'PioneerDevice' object has no attribute 'port'. Did you mean: '_port'?`
- **Root cause**: The attribute is defined as `self._port` in `__init__` but was incorrectly referenced as `self.port` in the exception handler
- **Introduced in**: Commit 8803ec2 (2021-11-16)
- **Trigger**: Only manifests when connection to the receiver fails

## Changes
Changed line 126 from:
```python
self._host, self.port)
```
to:
```python
self._host, self._port)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)