### PR TITLE
Change volume level log from warning to info

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -278,7 +278,7 @@ class PioneerDevice(MediaPlayerEntity):
         """Set volume level, range 0..1."""
         # 60dB max
 #        while (self._volume != volume)
-        _LOGGER.warning("Self: %f %f %d", self._volume,  volume, (self._volume - volume)* MAX_VOLUME/2)
+        _LOGGER.info("Self: %f %f %d", self._volume,  volume, (self._volume - volume)* MAX_VOLUME/2)
         
         for x in range(abs(round((self._volume - volume)* MAX_VOLUME/2))):
             if ((self._volume - volume)< 0):


### PR DESCRIPTION
## Summary
Changed log level from `warning` to `info` for volume level debug message to reduce log noise.

## Details
The volume level calculation message at line 281 was logging at warning level, causing it to appear as an error in logs even though it's just debug information showing volume change calculations.

## Changes
Changed line 281 from:
```python
_LOGGER.warning("Self: %f %f %d", ...)
```
to:
```python
_LOGGER.info("Self: %f %f %d", ...)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)